### PR TITLE
allow X to contain additional cols

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,12 @@
-# shapviz 0.3.0
+# shapviz 0.3.0 DEVEL
 
 #  Major improvement
 
-- The argument `X` of the constructor of `shapviz()` is now less picky. If it contains columns not present in the SHAP matrix, they are silently dropped. Furthermore, the column order of the SHAP matrix and `X` is determined by the SHAP matrix.
+- The argument `X` of the constructor of `shapviz()` is now less picky. If it contains columns not present in the SHAP matrix, they are silently dropped. Furthermore, the column order of the SHAP matrix and `X` is now determined by the SHAP matrix.
 
-## Removed
+## Removed (according to depreciation cycle)
 
-- Functions `shapviz_from_lgb_predict()` and `shapviz_from_xgb_predict`
+- Functions `shapviz_from_lgb_predict()` and `shapviz_from_xgb_predict()`
 - `format_fun` argument in `sv_force()` and `sv_waterfall()`
 - `sort_fun` argument in `sv_waterfall()`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # shapviz 0.3.0
 
-## Removed as announced
+#  Major improvement
+
+- The argument `X` of the constructor of `shapviz()` is now less picky. If it contains columns not present in the SHAP matrix, they are silently dropped. Furthermore, the column order of the SHAP matrix and `X` is determined by the SHAP matrix.
+
+## Removed
 
 - Functions `shapviz_from_lgb_predict()` and `shapviz_from_xgb_predict`
 - `format_fun` argument in `sv_force()` and `sv_waterfall()`

--- a/R/shapviz.R
+++ b/R/shapviz.R
@@ -20,17 +20,22 @@
 #' explicit value. SHAP values of dummy variables can be combined using the convenient
 #' \code{collapse} argument.
 #' @importFrom xgboost xgb.train
-#' @param object Object to be converted to an object of type "shapviz".
-#' @param X Corresponding matrix or data.frame of feature values used for visualization.
+#' @param object For XGBoost, LightGBM, and H2O, this is the fitted model used to
+#' calculate SHAP values from \code{X_pred}.
+#' In the other cases, it is the object containing the SHAP values.
+#' @param X Matrix or data.frame of feature values used for visualization.
+#' It must contain at least the same column names as the SHAP matrix represented by
+#' \code{object}/\code{X_pred} (after collapsing some of the SHAP columns).
 #' @param X_pred Data set as expected by the \code{predict} function of
 #' XGBoost, LightGBM, or H2O. For XGBoost, a matrix or \code{xgb.DMatrix},
 #' for LightGBM a matrix, and for H2O a \code{data.frame} or an \code{H2OFrame}.
+#' Only used for XGBoost, LightGBM, or H2O objects.
 #' @param baseline Optional baseline value, representing the average response at the
 #' scale of the SHAP values. It will be used for plot methods that explain single
 #' predictions.
 #' @param which_class In case of a multiclass or multioutput setting,
 #' which class/output (>= 1) to explain. Currently relevant for XGBoost, LightGBM,
-#' or kernelshap.
+#' and kernelshap.
 #' @param collapse A named list of character vectors. Each vector specifies a group of
 #' column names in the SHAP matrix that should be collapsed to a single column by summation.
 #' The name of the new column equals the name of the vector in \code{collapse}.
@@ -68,21 +73,21 @@ shapviz.matrix = function(object, X, baseline = 0, collapse = NULL, ...) {
   object <- collapse_shap(object, collapse = collapse)
   stopifnot(
     "'X' must be a matrix or data.frame" = is.matrix(X) || is.data.frame(X),
+    "'object' need at least one row and one column" = dim(object) >= 1L,
+    "'X' need at least one row and one column" = dim(X) >= 1L,
     "The number of rows of 'object' and 'X' differ" = nrow(object) == nrow(X),
-    "The number of columns of 'object' and 'X' differ" = ncol(object) == ncol(X),
-    "'X' and 'object' need at least one row and one column" = dim(X) >= 1L,
-    "SHAP matrix must have column names" = !is.null(colnames(object)),
+    "'object' must have column names" = !is.null(colnames(object)),
     "'X' must have column names" = !is.null(colnames(X)),
-    "'object' and 'X' must have the same column names" =
-      sort(colnames(object)) == sort(colnames(X)),
+    "'X' must contain all column names of 'object'" =
+      all(colnames(object) %in% colnames(X)),
     "No missing SHAP values allowed" = !anyNA(object),
     "'baseline' has to be a single number" =
       length(baseline) == 1L && is.numeric(baseline),
     "'baseline' cannot be NA" = !is.na(baseline)
   )
   out <- list(
-    S = object[, colnames(X), drop = FALSE],
-    X = as.data.frame(X),
+    S = object,
+    X = as.data.frame(X)[colnames(object)],
     baseline = baseline
   )
   class(out) <- "shapviz"
@@ -98,14 +103,15 @@ shapviz.matrix = function(object, X, baseline = 0, collapse = NULL, ...) {
 #'
 #' # Will use numeric matrix "X_pred" as feature matrix
 #' x <- shapviz(fit, X_pred = X_pred)
-#' sv_importance(x)
+#' x
+#' sv_dependence(x, "Species")
 #'
 #' # Will use original values as feature matrix
-#' x <- shapviz(fit, X_pred = X_pred, X = iris[, -1])
-#' sv_dependence(x, "Petal.Length", color_var = "auto")
+#' x <- shapviz(fit, X_pred = X_pred, X = iris)
+#' sv_dependence(x, "Species", color_var = "auto")
 #'
 #' # "X_pred" can also be passed as xgb.DMatrix, but only if X is passed as well!
-#' x <- shapviz(fit, X_pred = dtrain, X = iris[, -1])
+#' x <- shapviz(fit, X_pred = dtrain, X = iris)
 #'
 #' # Similarly with LightGBM
 #' if (requireNamespace("lightgbm", quietly = TRUE)) {
@@ -132,9 +138,10 @@ shapviz.matrix = function(object, X, baseline = 0, collapse = NULL, ...) {
 #' x <- shapviz(
 #'   fit,
 #'   X_pred = X_pred,
-#'   X = iris[, -1],
+#'   X = iris,
 #'   collapse = list(Species = c("Speciessetosa", "Speciesversicolor", "Speciesvirginica"))
 #' )
+#' x
 shapviz.xgb.Booster = function(object, X_pred, X = X_pred,
                                which_class = NULL, collapse = NULL, ...) {
   stopifnot(
@@ -249,24 +256,21 @@ shapviz.kernelshap <- function(object, X = object[["X"]],
 
 #' @describeIn shapviz Creates a "shapviz" object from a (tree-based) H2O regression model.
 #' @export
-shapviz.H2ORegressionModel = function(object, X_pred,
-                                      X = as.data.frame(X_pred)[object@parameters[["x"]]],
+shapviz.H2ORegressionModel = function(object, X_pred, X = as.data.frame(X_pred),
                                       collapse = NULL, ...) {
   shapviz.H2OModel(object = object, X_pred = X_pred, X = X, collapse = collapse, ...)
 }
 
 #' @describeIn shapviz Creates a "shapviz" object from a (tree-based) H2O binary classification model.
 #' @export
-shapviz.H2OBinomialModel = function(object, X_pred,
-                                    X = as.data.frame(X_pred)[object@parameters[["x"]]],
+shapviz.H2OBinomialModel = function(object, X_pred, X = as.data.frame(X_pred),
                                     collapse = NULL, ...) {
   shapviz.H2OModel(object = object, X_pred = X_pred, X = X, collapse = collapse, ...)
 }
 
 #' @describeIn shapviz Creates a "shapviz" object from a (tree-based) H2O model (base class).
 #' @export
-shapviz.H2OModel = function(object, X_pred,
-                            X = as.data.frame(X_pred)[object@parameters[["x"]]],
+shapviz.H2OModel = function(object, X_pred, X = as.data.frame(X_pred),
                             collapse = NULL, ...) {
   if (!requireNamespace("h2o", quietly = TRUE)) {
     stop("Package 'h2o' not installed")

--- a/R/shapviz.R
+++ b/R/shapviz.R
@@ -25,7 +25,7 @@
 #' In the other cases, it is the object containing the SHAP values.
 #' @param X Matrix or data.frame of feature values used for visualization.
 #' It must contain at least the same column names as the SHAP matrix represented by
-#' \code{object}/\code{X_pred} (after collapsing some of the SHAP columns).
+#' \code{object}/\code{X_pred} (after optionally collapsing some of the SHAP columns).
 #' @param X_pred Data set as expected by the \code{predict} function of
 #' XGBoost, LightGBM, or H2O. For XGBoost, a matrix or \code{xgb.DMatrix},
 #' for LightGBM a matrix, and for H2O a \code{data.frame} or an \code{H2OFrame}.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SHAP (SHapley Additive exPlanations, [1]) is an ingenious way to study black box
 These plots require a "shapviz" object, which is built from two things only:
 
 1. `S`: Matrix of SHAP values
-2. `X`: Dataset with corresponding feature values
+2. `X`: Dataset that includes the corresponding feature values
 
 Furthermore, a `baseline` can be passed to represent an average prediction on the scale of the SHAP values.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ To further simplify the use of "shapviz", we added direct connectors to the R pa
 - [`treeshap`](https://github.com/ModelOriented/treeshap), and
 - [`kernelshap`](https://github.com/mayer79/kernelshap)
 
+For XGBoost, LightGBM, and H2O, the SHAP values are directly calculated from the fitted model.
+
 [`CatBoost`](https://github.com/catboost) is not included, but see the vignette how to use its SHAP calculation backend with "shapviz".
 
 ## Installation
@@ -57,8 +59,8 @@ library(xgboost)
 
 set.seed(3653)
 
-X <- diamonds[c("carat", "cut", "color", "clarity")]
-dtrain <- xgb.DMatrix(data.matrix(X), label = diamonds$price)
+x <- c("carat", "cut", "color", "clarity")
+dtrain <- xgb.DMatrix(data.matrix(diamonds[x]), label = diamonds$price)
 
 fit <- xgb.train(
   params = list(learning_rate = 0.1, objective = "reg:squarederror"), 
@@ -74,9 +76,9 @@ One line of code creates a "shapviz" object. It contains SHAP values and feature
 In this example, we construct the "shapviz" object directly from the fitted XGBoost model. Thus we also need to pass a corresponding prediction dataset `X_pred` used for calculating SHAP values by XGBoost.
 
 ``` r
-X_small <- X[sample(nrow(X), 2000L), ]
+dia_small <- diamonds[sample(nrow(X), 2000L), ]
 
-shp <- shapviz(fit, X_pred = data.matrix(X_small), X = X_small)
+shp <- shapviz(fit, X_pred = data.matrix(dia_small[x]), X = dia_small)
 ```
 
 Note: If `X_pred` would contain one-hot-encoded dummy variables, their SHAP values could be collapsed by the `collapse` argument of `shapviz()`.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,6 @@
-# shapviz 0.2.2
+# shapviz 0.3.0
 
 Dear CRAN team
-
-This small update fixes a problem that occur with R versions < 4.1:
-
-I was using `apply(, ..., simplify = FALSE)`, which would fail for earlier R version. I was not aware of this.
 
 ## Checks
 
@@ -14,10 +10,3 @@ I was using `apply(, ..., simplify = FALSE)`, which would fail for earlier R ver
 
 ### check_rhub() and check_win_devel()
 
-* checking package dependencies ... NOTE
-  'h2o', 'lightgbm'
-  
-Packages which this enhances but not available for checking:
-* checking for detritus in the temp directory ... NOTE
-Found the following files/directories:
-  'lastMiKTeXException'

--- a/man/shapviz.Rd
+++ b/man/shapviz.Rd
@@ -39,37 +39,23 @@ shapviz(object, ...)
 
 \method{shapviz}{kernelshap}(object, X = object[["X"]], which_class = NULL, collapse = NULL, ...)
 
-\method{shapviz}{H2ORegressionModel}(
-  object,
-  X_pred,
-  X = as.data.frame(X_pred)[object@parameters[["x"]]],
-  collapse = NULL,
-  ...
-)
+\method{shapviz}{H2ORegressionModel}(object, X_pred, X = as.data.frame(X_pred), collapse = NULL, ...)
 
-\method{shapviz}{H2OBinomialModel}(
-  object,
-  X_pred,
-  X = as.data.frame(X_pred)[object@parameters[["x"]]],
-  collapse = NULL,
-  ...
-)
+\method{shapviz}{H2OBinomialModel}(object, X_pred, X = as.data.frame(X_pred), collapse = NULL, ...)
 
-\method{shapviz}{H2OModel}(
-  object,
-  X_pred,
-  X = as.data.frame(X_pred)[object@parameters[["x"]]],
-  collapse = NULL,
-  ...
-)
+\method{shapviz}{H2OModel}(object, X_pred, X = as.data.frame(X_pred), collapse = NULL, ...)
 }
 \arguments{
-\item{object}{Object to be converted to an object of type "shapviz".}
+\item{object}{For XGBoost, LightGBM, and H2O, this is the fitted model used to
+calculate SHAP values from \code{X_pred}.
+In the other cases, it is the object containing the SHAP values.}
 
 \item{...}{Parameters passed to other methods (currently only used by
 the \code{predict} functions of XGBoost, LightGBM, and H2O).}
 
-\item{X}{Corresponding matrix or data.frame of feature values used for visualization.}
+\item{X}{Matrix or data.frame of feature values used for visualization.
+It must contain at least the same column names as the SHAP matrix represented by
+\code{object}/\code{X_pred} (after collapsing some of the SHAP columns).}
 
 \item{baseline}{Optional baseline value, representing the average response at the
 scale of the SHAP values. It will be used for plot methods that explain single
@@ -81,11 +67,12 @@ The name of the new column equals the name of the vector in \code{collapse}.}
 
 \item{X_pred}{Data set as expected by the \code{predict} function of
 XGBoost, LightGBM, or H2O. For XGBoost, a matrix or \code{xgb.DMatrix},
-for LightGBM a matrix, and for H2O a \code{data.frame} or an \code{H2OFrame}.}
+for LightGBM a matrix, and for H2O a \code{data.frame} or an \code{H2OFrame}.
+Only used for XGBoost, LightGBM, or H2O objects.}
 
 \item{which_class}{In case of a multiclass or multioutput setting,
 which class/output (>= 1) to explain. Currently relevant for XGBoost, LightGBM,
-or kernelshap.}
+and kernelshap.}
 }
 \value{
 An object of class "shapviz" with the following three elements:
@@ -152,14 +139,15 @@ fit <- xgboost::xgb.train(data = dtrain, nrounds = 50)
 
 # Will use numeric matrix "X_pred" as feature matrix
 x <- shapviz(fit, X_pred = X_pred)
-sv_importance(x)
+x
+sv_dependence(x, "Species")
 
 # Will use original values as feature matrix
-x <- shapviz(fit, X_pred = X_pred, X = iris[, -1])
-sv_dependence(x, "Petal.Length", color_var = "auto")
+x <- shapviz(fit, X_pred = X_pred, X = iris)
+sv_dependence(x, "Species", color_var = "auto")
 
 # "X_pred" can also be passed as xgb.DMatrix, but only if X is passed as well!
-x <- shapviz(fit, X_pred = dtrain, X = iris[, -1])
+x <- shapviz(fit, X_pred = dtrain, X = iris)
 
 # Similarly with LightGBM
 if (requireNamespace("lightgbm", quietly = TRUE)) {
@@ -186,9 +174,10 @@ fit <- xgboost::xgb.train(data = dtrain, nrounds = 50)
 x <- shapviz(
   fit,
   X_pred = X_pred,
-  X = iris[, -1],
+  X = iris,
   collapse = list(Species = c("Speciessetosa", "Speciesversicolor", "Speciesvirginica"))
 )
+x
 }
 \seealso{
 \code{\link{sv_importance}}, \code{\link{sv_dependence}},

--- a/man/shapviz.Rd
+++ b/man/shapviz.Rd
@@ -55,7 +55,7 @@ the \code{predict} functions of XGBoost, LightGBM, and H2O).}
 
 \item{X}{Matrix or data.frame of feature values used for visualization.
 It must contain at least the same column names as the SHAP matrix represented by
-\code{object}/\code{X_pred} (after collapsing some of the SHAP columns).}
+\code{object}/\code{X_pred} (after optionally collapsing some of the SHAP columns).}
 
 \item{baseline}{Optional baseline value, representing the average response at the
 scale of the SHAP values. It will be used for plot methods that explain single

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -14,14 +14,17 @@ test_that("dim, nrow, ncol work", {
   expect_equal(ncol(shp), 2L)
 })
 
-test_that("column order of S does no matter", {
-  expect_equal(shp, shapviz(S[, 2:1], X, baseline = 4))
+test_that("column order of X does no matter", {
+  expect_equal(shp, shapviz(S, X[, 2:1], baseline = 4))
+})
+
+test_that("X can contain additional columns", {
+  expect_equal(shp, shapviz(S, X = cbind(X, z = 1:2), baseline = 4))
 })
 
 test_that("some input checks fire", {
   expect_error(shapviz(S[1, , drop = FALSE], X))
   expect_error(shapviz(S, X[1, ]))
-  expect_error(shapviz(S[, 1, drop = FALSE], X))
   expect_error(shapviz(S, X[, 1]))
   expect_error(shapviz(matrix(S, ncol = 2, dimnames = list(NULL, c("d", "e"))), X))
   expect_error(shapviz(matrix(S, ncol = 2, dimnames = list(NULL, NULL)), X))

--- a/vignettes/shapviz.Rmd
+++ b/vignettes/shapviz.Rmd
@@ -33,7 +33,7 @@ SHAP (SHapley Additive exPlanations, see @lundberg2017) is an ingenious way to s
 These plots require a "shapviz" object, which is built from two things only:
 
 1. `S`: Matrix of SHAP values
-2. `X`: Dataset with corresponding feature values
+2. `X`: Dataset that includes the corresponding feature values
 
 Furthermore, a `baseline` can be passed to represent an average prediction on the scale of the SHAP values.
 
@@ -49,6 +49,8 @@ To further simplify the use of "shapviz", we added direct connectors to the R pa
 - [`h2o`](https://CRAN.R-project.org/package=h2o),
 - [`treeshap`](https://github.com/ModelOriented/treeshap), and
 - [`kernelshap`](https://github.com/mayer79/kernelshap)
+
+For XGBoost, LightGBM, and H2O, the SHAP values are directly calculated from the fitted model.
 
 [`CatBoost`](https://github.com/catboost) is not included, but see Section "Any other package" how to use its SHAP calculation backend with "shapviz".
 
@@ -76,10 +78,12 @@ library(xgboost)
 
 set.seed(3653)
 
+# Turn ordinal factors into normal ones
 ord <- c("clarity", "cut", "color")
 diamonds[, ord] <- lapply(diamonds[, ord], factor, ordered = FALSE)
 
-x <- c("carat", ord)
+# Fit XGBoost model
+x <- c("carat", "clarity", "cut", "color")
 dtrain <- xgb.DMatrix(data.matrix(diamonds[x]), label = diamonds$price)
 
 fit <- xgb.train(
@@ -96,9 +100,10 @@ One line of code creates a "shapviz" object. It contains SHAP values and feature
 In this example we construct the "shapviz" object directly from the fitted XGBoost model. Thus we also need to pass a corresponding prediction dataset `X_pred` used for calculating SHAP values by XGBoost.
 
 ```{r}
+# Pick explanation data
 dia_small <- diamonds[sample(nrow(diamonds), 2000L), ]
 
-# X is the "explanation" dataset using the original factors
+# We also pass feature data X with originally encoded values
 shp <- shapviz(fit, X_pred = data.matrix(dia_small[x]), X = dia_small)
 ```
 
@@ -170,10 +175,19 @@ sv_importance(shp)
 ```r
 library(fastshap)
 
-fit <- lm(price ~ carat + clarity + cut + color, data = diamonds)
-explainer <- explain(fit, newdata = dia_small, exact = TRUE)
-shp <- shapviz(explainer, X = dia_small)
-sv_dependence(shp, "carat")
+# SHAP sampling values using iris data
+fit <- lm(Sepal.Length ~ Sepal.Width + Petal.Length, data = iris)
+
+shap <- explain(
+  fit, 
+  X = iris[c("Sepal.Width", "Petal.Length")], 
+  newdata = iris[c("Sepal.Width", "Petal.Length")], 
+  nsim = 100, 
+  pred_wrapper = predict
+)
+
+sv <- shapviz(shap, X = iris)
+sv_dependence(sv, "Sepal.Width")
 ```
 ### shapr
 
@@ -234,7 +248,7 @@ sv_dependence(shp, "clarity", color_var = "auto", alpha = 0.2, size = 1)
 ```r
 library(kernelshap)
 
-dia_smaller <- diamonds[sample(nrow(X), 100L), ]
+dia_smaller <- diamonds[sample(nrow(diamonds), 100L), ]
 fit <- lm(price ~ carat + clarity + cut + color, data = diamonds)
 ks <- kernelshap(fit, dia_small[x], bg_X = dia_smaller)
 
@@ -286,9 +300,7 @@ shapviz.catboost.Model <- function(object, X_pred, X = X_pred, collapse = NULL, 
 }
 
 # Example
-
-X <- diamonds[x]
-X_pool <- catboost.load_pool(X, label = diamonds$price)
+X_pool <- catboost.load_pool(diamonds[x], label = diamonds$price)
 
 fit <- catboost.train(
   X_pool, 

--- a/vignettes/shapviz.Rmd
+++ b/vignettes/shapviz.Rmd
@@ -79,8 +79,8 @@ set.seed(3653)
 ord <- c("clarity", "cut", "color")
 diamonds[, ord] <- lapply(diamonds[, ord], factor, ordered = FALSE)
 
-X <- diamonds[c("carat", "cut", "color", "clarity")]
-dtrain <- xgb.DMatrix(data.matrix(X), label = diamonds$price)
+x <- c("carat", ord)
+dtrain <- xgb.DMatrix(data.matrix(diamonds[x]), label = diamonds$price)
 
 fit <- xgb.train(
   params = list(learning_rate = 0.1, objective = "reg:squarederror"), 
@@ -96,10 +96,10 @@ One line of code creates a "shapviz" object. It contains SHAP values and feature
 In this example we construct the "shapviz" object directly from the fitted XGBoost model. Thus we also need to pass a corresponding prediction dataset `X_pred` used for calculating SHAP values by XGBoost.
 
 ```{r}
-X_small <- X[sample(nrow(X), 2000L), ]
+dia_small <- diamonds[sample(nrow(diamonds), 2000L), ]
 
 # X is the "explanation" dataset using the original factors
-shp <- shapviz(fit, X_pred = data.matrix(X_small), X = X_small)
+shp <- shapviz(fit, X_pred = data.matrix(dia_small[x]), X = dia_small)
 ```
 
 Note: If `X_pred` would contain one-hot-encoded dummy variables, their SHAP values could be collapsed by the `collapse` argument of `shapviz()`.
@@ -154,7 +154,7 @@ The above example uses XGBoost to calculate SHAP values. In the following sectio
 
 ```r
 library(lightgbm)
-dtrain <- lgb.Dataset(data.matrix(X), label = diamonds$price)
+dtrain <- lgb.Dataset(data.matrix(diamonds[x]), label = diamonds$price)
 
 fit <- lgb.train(
   params = list(learning_rate = 0.1, objective = "regression"), 
@@ -162,7 +162,7 @@ fit <- lgb.train(
   nrounds = 65L
 )
 
-shp <- shapviz(fit, X_pred = data.matrix(X_small), X = X_small)
+shp <- shapviz(fit, X_pred = data.matrix(dia_small[x]), X = dia_small)
 sv_importance(shp)
 ```
 ### fastshap
@@ -171,8 +171,8 @@ sv_importance(shp)
 library(fastshap)
 
 fit <- lm(price ~ carat + clarity + cut + color, data = diamonds)
-explainer <- explain(fit, newdata = X_small, exact = TRUE)
-shp <- shapviz(explainer, X = X_small)
+explainer <- explain(fit, newdata = dia_small, exact = TRUE)
+shp <- shapviz(explainer, X = dia_small)
 sv_dependence(shp, "carat")
 ```
 ### shapr
@@ -181,13 +181,13 @@ sv_dependence(shp, "carat")
 library(shapr)
 
 fit <- lm(price ~ carat + clarity + cut + color, data = diamonds)
-X_smaller <- X[sample(nrow(X), 200L), ]
+dia_smaller <- diamonds[sample(nrow(X), 20L), ]
 
-explainer <- shapr(X_smaller, fit,)
+explainer <- shapr(dia_smaller, fit)
 
 # Takes about 15 seconds
 explanation <- explain(
-  X_smaller,
+  dia_smaller,
   approach = "ctree",
   explainer = explainer,
   prediction_zero = mean(diamonds$price)
@@ -208,10 +208,10 @@ h2o.init()
 
 dia_h2o <- as.h2o(diamonds)
 
-fit <- h2o.gbm(c("carat", "clarity", "color", "cut"), "price", training_frame = dia_h2o)
-x <- shapviz(fit, X_pred = X_small)
-sv_force(x, row_id = 1)
-sv_dependence(x, "carat", "auto")
+fit <- h2o.gbm(x, "price", training_frame = dia_h2o)
+shp <- shapviz(fit, X_pred = dia_small)
+sv_force(shp, row_id = 1)
+sv_dependence(shp, "carat", "auto")
 ```
 
 ### treeshap
@@ -220,7 +220,7 @@ sv_dependence(x, "carat", "auto")
 library(treeshap)
 library(ranger)
 
-fit <- ranger(y = diamonds$price, x = data.matrix(X), max.depth = 6, num.trees = 100)
+fit <- ranger(y = diamonds$price, x = data.matrix(X), max.depth = 4, num.trees = 100)
 unified_model <- ranger.unify(fit, data.matrix(X))
 shaps <- treeshap(unified_model, data.matrix(X_small))
 shp <- shapviz(shaps, X = X_small)
@@ -233,9 +233,9 @@ sv_dependence(shp, "clarity", color_var = "auto", alpha = 0.2, size = 1)
 ```r
 library(kernelshap)
 
-X_smaller <- X[sample(nrow(X), 200L), ]
+dia_smaller <- diamonds[sample(nrow(X), 100L), ]
 fit <- lm(price ~ carat + clarity + cut + color, data = diamonds)
-ks <- kernelshap(fit, X_small, bg_X = X_smaller)
+ks <- kernelshap(fit, dia_small[x], bg_X = dia_smaller)
 
 shp <- shapviz(ks)
 sv_importance(shp)
@@ -286,8 +286,8 @@ shapviz.catboost.Model <- function(object, X_pred, X = X_pred, collapse = NULL, 
 
 # Example
 
-X <- diamonds[c("carat", "cut", "color", "clarity")]
-X_pool <- catboost.load_pool(diamonds[colnames(X)], label = diamonds$price)
+X <- diamonds[x]
+X_pool <- catboost.load_pool(X, label = diamonds$price)
 
 fit <- catboost.train(
   X_pool, 
@@ -299,7 +299,7 @@ fit <- catboost.train(
   )
 )
 
-shp <- shapviz(fit, X_small)
+shp <- shapviz(fit, X_pred = dia_small[x])
 sv_importance(shp)
 sv_dependence(shp, "clarity", color_var = "auto", alpha = 0.2, size = 1)
 ```

--- a/vignettes/shapviz.Rmd
+++ b/vignettes/shapviz.Rmd
@@ -181,11 +181,10 @@ sv_dependence(shp, "carat")
 library(shapr)
 
 fit <- lm(price ~ carat + clarity + cut + color, data = diamonds)
-dia_smaller <- diamonds[sample(nrow(X), 20L), ]
+dia_smaller <- diamonds[sample(nrow(diamonds), 20L), ]
 
 explainer <- shapr(dia_smaller, fit)
 
-# Takes about 15 seconds
 explanation <- explain(
   dia_smaller,
   approach = "ctree",
@@ -220,10 +219,12 @@ sv_dependence(shp, "carat", "auto")
 library(treeshap)
 library(ranger)
 
-fit <- ranger(y = diamonds$price, x = data.matrix(X), max.depth = 4, num.trees = 100)
-unified_model <- ranger.unify(fit, data.matrix(X))
-shaps <- treeshap(unified_model, data.matrix(X_small))
-shp <- shapviz(shaps, X = X_small)
+fit <- ranger(
+  y = diamonds$price, x = data.matrix(diamonds[x]), max.depth = 4, num.trees = 100
+)
+unified_model <- ranger.unify(fit, data.matrix(diamonds[x]))
+shaps <- treeshap(unified_model, data.matrix(dia_small[x]))
+shp <- shapviz(shaps, X = dia_small)
 sv_importance(shp)
 sv_dependence(shp, "clarity", color_var = "auto", alpha = 0.2, size = 1)
 ```


### PR DESCRIPTION
The current shapviz() interface is very picky regarding X: It must have the same column names as the SHAP matrix. This PR relaxes this and allows X to contain additional columns that are dropped in the constructor.