### PR TITLE
Hide "other" in importance plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shapviz
 Title: SHAP Visualizations
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: 
     person("Michael", "Mayer", , "mayermichael79@gmail.com", role = c("aut", "cre"))
 Description: Visualizations for SHAP (SHapley Additive exPlanations), such

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# shapviz 0.4.1 DEVEL
+
+## New functionalities
+
+- Hide "other": `sv_importance()` has received a new argument `show_others = TRUE`. Set to `FALSE` to hide the "other" bar/beeswarm.
+
 # shapviz 0.4.0
 
 ## Removed dependencies

--- a/R/bee.R
+++ b/R/bee.R
@@ -50,13 +50,13 @@ ave2 <- function(x, g = NULL, FUN = mean, ...) {
   x
 }
 
-# First n values of the Halton sequence
+# First n values of the 1-dimensional Halton sequence (= van der Corput sequence)
+# https://en.wikipedia.org/wiki/Halton_sequence
 halton_sequence <- function(n, b = 2) {
   vapply(seq_len(n), halton, FUN.VALUE = 0.0)
 }
 
-# i-th element of Holton sequence
-# https://en.wikipedia.org/wiki/Halton_sequence
+# i-th element of above sequence
 halton <- function(i, b = 2) {
   f <- 1
   r <- 0

--- a/R/sv_importance.R
+++ b/R/sv_importance.R
@@ -14,12 +14,12 @@
 #' @param kind Should a "bar" plot (the default), a "beeswarm" plot, or "both" be shown?
 #' Set to "no" in order to suppress plotting. In that case, the sorted
 #' SHAP feature importances of all variables are returned.
-#' @param max_display Maximum number of features (with highest importance)
-#' should be plotted? If there are more and \code{show_other = TRUE},
-#' the least important variables are collapsed:
+#' @param max_display Maximum number of features (with highest importance) to plot.
+#' If there are more, the least important variables are collapsed to an "other" group:
 #' their SHAP values are added and their min-max-scaled feature values are added as
-#' well (and the resulting vector is min-max-scaled again). Set to \code{Inf} to show
-#' all features. Has no effect if \code{kind = "no"}.
+#' well (and the resulting vector is min-max-scaled again).
+#' Set to \code{Inf} to show all features.
+#' Has no effect if \code{kind = "no"} or if \code{show_other = FALSE}.
 #' @param show_other If the number of features is larger than \code{max_display}:
 #' Should the "other" group be shown (default) or not?
 #' @param fill Color used to fill the bars (only used if bars are shown).
@@ -102,19 +102,29 @@ sv_importance.shapviz <- function(object, kind = c("bar", "beeswarm", "both", "n
   X_tmp <- apply(data.matrix(X), 2L, FUN = .min_max_scale)
   X_scaled <- as.data.frame(if (nrow(X) >= 2L) X_tmp else t(X_tmp))
 
-  # Collapse unimportant features (here, it is important that 'imp' is sorted)
-  ok <- utils::head(names(imp), max_display - 1L)
-  if (length(ok) < ncol(X) - 1L) {
-    bad <- setdiff(colnames(X), ok)
-    nn <- paste("Sum of", length(bad), "other")
+  # Deal with too many features -> important: "imp" is sorted
+  if (ncol(S) > max_display) {
+    if (!show_other) {
+      imp <- imp[seq_len(max_display)]
+      S <- S[, names(imp), drop = FALSE]
+      X_scaled <- X_scaled[names(imp)]
+    } else {
+      to_keep <- names(imp[seq_len(max_display - 1L)])
+      to_collapse <- setdiff(colnames(S), to_keep)
 
-    X_scaled_bad <- rowSums(X_scaled[bad])
-    X_scaled <- X_scaled[ok]
-    X_scaled[[nn]] <- .min_max_scale(X_scaled_bad)
+      # Collapse scaled feature values
+      other_name <- paste("Sum of", length(to_collapse), "other")
+      collapsed <- .min_max_scale(rowSums(X_scaled[to_collapse]))
+      X_scaled <- X_scaled[to_keep]
+      X_scaled[[other_name]] <- collapsed
 
-    S <- cbind(S[, ok, drop = FALSE], rowSums(S[, bad, drop = FALSE]))
-    colnames(S) <- c(ok, nn)
-    imp <- .get_imp(S)
+      # Collapse SHAP values
+      S <- cbind(S[, to_keep, drop = FALSE], rowSums(S[, to_collapse, drop = FALSE]))
+      colnames(S) <- c(to_keep, other_name)
+
+      # Recalculate importances (only "other" is new/different)
+      imp <- .get_imp(S)
+    }
   }
 
   imp_df <- data.frame(feature = stats::reorder(names(imp), imp), value = imp)

--- a/R/sv_importance.R
+++ b/R/sv_importance.R
@@ -62,6 +62,8 @@
 #' S <- as.matrix(X)
 #' x2 <- shapviz(S, X)
 #' sv_importance(x2)
+#' sv_importance(x2, max_display = 5)
+#' sv_importance(x2, max_display = 5, show_other = FALSE)
 sv_importance <- function(object, ...) {
   UseMethod("sv_importance")
 }

--- a/R/sv_importance.R
+++ b/R/sv_importance.R
@@ -15,10 +15,13 @@
 #' Set to "no" in order to suppress plotting. In that case, the sorted
 #' SHAP feature importances of all variables are returned.
 #' @param max_display Maximum number of features (with highest importance)
-#' should be plotted? If there are more, the least important variables are collapsed:
+#' should be plotted? If there are more and \code{show_other = TRUE},
+#' the least important variables are collapsed:
 #' their SHAP values are added and their min-max-scaled feature values are added as
 #' well (and the resulting vector is min-max-scaled again). Set to \code{Inf} to show
 #' all features. Has no effect if \code{kind = "no"}.
+#' @param show_other If the number of features is larger than \code{max_display}:
+#' Should the "other" group be shown (default) or not?
 #' @param fill Color used to fill the bars (only used if bars are shown).
 #' @param bar_width Relative width of the bars (only used if bars are shown).
 #' @param bee_width Relative width of the beeswarms (only used if beeswarm shown).
@@ -72,7 +75,8 @@ sv_importance.default <- function(object, ...) {
 #' @describeIn sv_importance SHAP importance plot for an object of class "shapviz".
 #' @export
 sv_importance.shapviz <- function(object, kind = c("bar", "beeswarm", "both", "no"),
-                                  max_display = 15L, fill = "#fca50a", bar_width = 2/3,
+                                  max_display = 15L, show_other = TRUE,
+                                  fill = "#fca50a", bar_width = 2/3,
                                   bee_width = 0.4, bee_adjust = 0.5,
                                   viridis_args = getOption("shapviz.viridis_args"),
                                   color_bar_title = "Feature value",

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ To further simplify the use of "shapviz", we added direct connectors to the R pa
 
 - [`XGBoost`](https://CRAN.R-project.org/package=xgboost),
 - [`LightGBM`](https://CRAN.R-project.org/package=lightgbm),
+- [`h2o`](https://CRAN.R-project.org/package=h2o),
+- [`kernelshap`](https://CRAN.R-project.org/package=kernelshap)
 - [`fastshap`](https://CRAN.R-project.org/package=fastshap),
 - [`shapr`](https://CRAN.R-project.org/package=shapr), 
-- [`h2o`](https://CRAN.R-project.org/package=h2o),
 - [`treeshap`](https://github.com/ModelOriented/treeshap), and
-- [`kernelshap`](https://github.com/mayer79/kernelshap)
 
 For XGBoost, LightGBM, and H2O, the SHAP values are directly calculated from the fitted model.
 

--- a/man/sv_importance.Rd
+++ b/man/sv_importance.Rd
@@ -14,6 +14,7 @@ sv_importance(object, ...)
   object,
   kind = c("bar", "beeswarm", "both", "no"),
   max_display = 15L,
+  show_other = TRUE,
   fill = "#fca50a",
   bar_width = 2/3,
   bee_width = 0.4,
@@ -38,11 +39,15 @@ and setting \code{size = 3} will produce larger dots.}
 Set to "no" in order to suppress plotting. In that case, the sorted
 SHAP feature importances of all variables are returned.}
 
-\item{max_display}{Maximum number of features (with highest importance)
-should be plotted? If there are more, the least important variables are collapsed:
+\item{max_display}{Maximum number of features (with highest importance) to plot.
+If there are more, the least important variables are collapsed to an "other" group:
 their SHAP values are added and their min-max-scaled feature values are added as
-well (and the resulting vector is min-max-scaled again). Set to \code{Inf} to show
-all features. Has no effect if \code{kind = "no"}.}
+well (and the resulting vector is min-max-scaled again).
+Set to \code{Inf} to show all features.
+Has no effect if \code{kind = "no"} or if \code{show_other = FALSE}.}
+
+\item{show_other}{If the number of features is larger than \code{max_display}:
+Should the "other" group be shown (default) or not?}
 
 \item{fill}{Color used to fill the bars (only used if bars are shown).}
 

--- a/man/sv_importance.Rd
+++ b/man/sv_importance.Rd
@@ -113,4 +113,6 @@ X <- data.frame(matrix(rnorm(1000), ncol = 20))
 S <- as.matrix(X)
 x2 <- shapviz(S, X)
 sv_importance(x2)
+sv_importance(x2, max_display = 5)
+sv_importance(x2, max_display = 5, show_other = FALSE)
 }

--- a/packaging.R
+++ b/packaging.R
@@ -15,7 +15,7 @@ library(usethis)
 use_description(
   fields = list(
     Title = "SHAP Visualizations",
-    Version = "0.4.0",
+    Version = "0.4.1",
     Description = "Visualizations for SHAP (SHapley Additive exPlanations),
     such as waterfall plots, force plots, various types of importance plots,
     and dependence plots.

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -16,6 +16,13 @@ test_that("using 'max_display' gives no error", {
   expect_s3_class(sv_importance(x, max_display = 2L), "ggplot")
 })
 
+test_that("using 'show_other = FALSE' gives no error", {
+  expect_s3_class(sv_importance(x, max_display = 2L, show_other = FALSE), "ggplot")
+  expect_s3_class(
+    sv_importance(x, max_display = 2L, show_other = FALSE, kind = "beeswarm"), "ggplot"
+  )
+})
+
 # Now with non-standard name
 ir <- iris
 ir["strange name"] <- ir$Sepal.Width * ir$Petal.Length
@@ -27,6 +34,8 @@ test_that("plots work for non-syntactic column names", {
   expect_s3_class(sv_waterfall(x, 2), "ggplot")
   expect_s3_class(sv_force(x, 2), "ggplot")
   expect_s3_class(sv_importance(x), "ggplot")
+  expect_s3_class(sv_importance(x, max_display = 2, kind = "beeswarm"), "ggplot")
+  expect_s3_class(sv_importance(x, max_display = 2, show_other = FALSE), "ggplot")
   expect_s3_class(sv_importance(x, kind = "beeswarm"), "ggplot")
   expect_s3_class(sv_dependence(x, "strange name", color_var = "auto"), "ggplot")
   expect_s3_class(

--- a/vignettes/shapviz.Rmd
+++ b/vignettes/shapviz.Rmd
@@ -44,11 +44,11 @@ To further simplify the use of "shapviz", we added direct connectors to the R pa
 
 - [`XGBoost`](https://CRAN.R-project.org/package=xgboost),
 - [`LightGBM`](https://CRAN.R-project.org/package=lightgbm),
+- [`h2o`](https://CRAN.R-project.org/package=h2o),
+- [`kernelshap`](https://CRAN.R-project.org/package=kernelshap)
 - [`fastshap`](https://CRAN.R-project.org/package=fastshap), 
 - [`shapr`](https://CRAN.R-project.org/package=shapr),
-- [`h2o`](https://CRAN.R-project.org/package=h2o),
 - [`treeshap`](https://github.com/ModelOriented/treeshap), and
-- [`kernelshap`](https://github.com/mayer79/kernelshap)
 
 For XGBoost, LightGBM, and H2O, the SHAP values are directly calculated from the fitted model.
 


### PR DESCRIPTION
This PR implements a new argument `show_other = TRUE` in `sv_importance()`. If `FALSE`, just the top `max_display` variables are shown, without collapsing to a group "other".